### PR TITLE
Fix default API base URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import process from 'process';
 
-const API_BASE = process.env.LM_BASE_URL || 'http://192.168.3.159:1234/v1';
+const API_BASE = process.env.LM_BASE_URL || 'http://localhost:1234/v1';
 const MODEL = process.env.LM_MODEL || 'google/gemma-3-4b';
 
 async function chat(messages) {


### PR DESCRIPTION
## Summary
- update default API_BASE to use localhost

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a8667defc832982ab917efd43e03a