### PR TITLE
Add interactive chat mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ pnpm install --global .
 lmstudio-agent "Descreva sua tarefa"
 ```
 
+Para um bate-papo interativo, execute:
+
+```bash
+lmstudio-agent --repl
+```
+Digite `exit` para sair do modo interativo.
+
 Se receber `lmstudio-agent: command not found`, verifique se o diretório de binários globais do pnpm está no seu `PATH`.
 Execute `pnpm setup` ou adicione `~/.local/share/pnpm` (ou o caminho equivalente no seu sistema) à variável `PATH`.
 


### PR DESCRIPTION
## Summary
- expand CLI with a `--repl` option for interactive sessions
- update README with instructions on using the interactive mode

## Testing
- `node --check index.js`
- `node index.js --repl <<'EOF'
exit
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684a883def84832996afb8ba71b6ab62