### PR TITLE
Improve system instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ lmstudio-agent --repl
 ```
 Digite `exit` para sair do modo interativo.
 
+### Exemplo
+
+Para descobrir a versão do sistema operacional você pode executar:
+
+```bash
+lmstudio-agent "Qual a versão do meu sistema?"
+```
+O modelo utiliza a função `cmd` para rodar comandos como `uname -a` ou `lsb_release -a` e retornar o resultado.
+
 Se receber `lmstudio-agent: command not found`, verifique se o diretório de binários globais do pnpm está no seu `PATH`.
 Execute `pnpm setup` ou adicione `~/.local/share/pnpm` (ou o caminho equivalente no seu sistema) à variável `PATH`.
 

--- a/index.js
+++ b/index.js
@@ -125,7 +125,8 @@ async function main() {
     process.exit(1);
   }
   const docs = loadProjectDocs();
-  let systemContent = 'Você é um agente de código que executa comandos e aplica patches usando funções.';
+  let systemContent = 'Você é um agente de código que executa comandos e aplica patches usando funções. ' +
+    'Sempre que a tarefa exigir informações do sistema ou manipulação de arquivos, utilize as funções "cmd" ou "apply_patch" e retorne a saída resultante.';
   if(docs) {
     systemContent += '\n\nContexto do projeto:\n' + docs;
   }


### PR DESCRIPTION
## Summary
- clarify to the model that it should use functions when needing system info
- document example usage in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a896b5ab08329b3b360bd44c17777