### PR TITLE
Update API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ O modelo utiliza a função `cmd` para rodar comandos como `uname -a` ou `lsb_re
 Se receber `lmstudio-agent: command not found`, verifique se o diretório de binários globais do pnpm está no seu `PATH`.
 Execute `pnpm setup` ou adicione `~/.local/share/pnpm` (ou o caminho equivalente no seu sistema) à variável `PATH`.
 
-O agente comunica‑se com o endpoint OpenAI compatível do LM Studio (por padrão `http://localhost:1234/v1`).
+O agente comunica‑se com o endpoint OpenAI compatível do LM Studio (por padrão `http://45.161.201.27:1234/v1`).
 
 Variáveis de ambiente:
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import path from 'path';
 import process from 'process';
 import readline from 'readline';
 
-const API_BASE = process.env.LM_BASE_URL || 'http://localhost:1234/v1';
+const API_BASE = process.env.LM_BASE_URL || 'http://45.161.201.27:1234/v1';
 const MODEL = process.env.LM_MODEL || 'google/gemma-3-4b';
 
 async function chat(messages) {


### PR DESCRIPTION
## Summary
- change default API endpoint to 45.161.201.27
- update README

## Testing
- `curl -I http://45.161.201.27:1234/v1/models`
- `node index.js "Olá"`

------
https://chatgpt.com/codex/tasks/task_e_684a8bd886b8832989bd65828f37d2af