### PR TITLE
Adicionar testes básicos

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import process from 'process';
 import readline from 'readline';
+import {pathToFileURL} from 'url';
 
 const API_BASE = process.env.LM_BASE_URL || 'http://45.161.201.27:1234/v1';
 const MODEL = process.env.LM_MODEL || 'google/gemma-3-4b';
@@ -158,7 +159,11 @@ async function main() {
   }
 }
 
-main().catch(err => {
-  console.error(err);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+export {chat, runCommand, applyPatch, loadProjectDocs, processChat, main};

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "type": "module",
   "bin": {
     "lmstudio-agent": "index.js"
+  },
+  "scripts": {
+    "test": "node --test"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,37 @@
+import assert from 'assert';
+import fs from 'fs';
+import {mkdtempSync} from 'fs';
+import {tmpdir} from 'os';
+import {join} from 'path';
+import {spawnSync} from 'child_process';
+import {test} from 'node:test';
+import {loadProjectDocs, runCommand, applyPatch} from '../index.js';
+
+
+test('loadProjectDocs inclui conteudo do README', () => {
+  const docs = loadProjectDocs();
+  assert.ok(docs.includes('Agente LM Studio'));
+});
+
+test('runCommand retorna saida do comando', () => {
+  const out = runCommand('echo hello');
+  assert.strictEqual(out.trim(), 'hello');
+});
+
+test('applyPatch aplica patch git', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'agent-test-'));
+  const cwd = process.cwd();
+  process.chdir(dir);
+  spawnSync('git', ['init'], {encoding: 'utf8'});
+  fs.writeFileSync('foo.txt', 'hello\n');
+  spawnSync('git', ['add', 'foo.txt'], {encoding: 'utf8'});
+  spawnSync('git', ['commit', '-m', 'init'], {encoding: 'utf8'});
+  fs.writeFileSync('foo.txt', 'world\n');
+  const diff = spawnSync('git', ['diff'], {encoding: 'utf8'}).stdout;
+  spawnSync('git', ['checkout', '--', 'foo.txt'], {encoding: 'utf8'});
+  const result = applyPatch(diff);
+  assert.strictEqual(result.trim(), 'patch aplicado com sucesso');
+  const content = fs.readFileSync('foo.txt', 'utf8');
+  assert.strictEqual(content, 'world\n');
+  process.chdir(cwd);
+});


### PR DESCRIPTION
## Summary
- exportar funções de `index.js` para permitir testes
- adicionar script de teste em `package.json`
- criar `test/index.test.js` com testes para `loadProjectDocs`, `runCommand` e `applyPatch`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684a8d06c44483298880bd7027c3cbe6