### PR TITLE
Add file utilities and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Contributor Guidelines
+
+- Run `npm test` (or `pnpm test`) before committing to ensure all tests pass.
+- Keep code formatted with 2-space indentation.
+- Write documentation and comments in Portuguese.
+- Tests live in the `test/` directory and use `node:test`.

--- a/README.md
+++ b/README.md
@@ -35,11 +35,17 @@ Variáveis de ambiente:
 - `LM_BASE_URL` – URL da API do LM Studio.
 - `LM_MODEL` – modelo a ser utilizado.
 
-O agente suporta três funções especiais que o modelo pode acionar:
+O agente suporta várias funções especiais que o modelo pode acionar:
 
 - `cmd` – executa um comando no shell e retorna a saída.
 - `apply_patch` – aplica um patch Git no repositório atual.
+- `read_file` – lê o conteúdo de um arquivo.
+- `list_files` – lista os arquivos de um diretório.
 - `done` – encerra a sessão.
+
+### Testes
+
+Execute `npm test` para rodar a suíte de testes automatizados.
 
 ## Licença
 

--- a/index.js
+++ b/index.js
@@ -43,6 +43,28 @@ async function chat(messages) {
           }
         },
         {
+          name: 'read_file',
+          description: 'Lê o conteúdo de um arquivo',
+          parameters: {
+            type: 'object',
+            properties: {
+              path: { type: 'string' }
+            },
+            required: ['path']
+          }
+        },
+        {
+          name: 'list_files',
+          description: 'Lista arquivos em um diretório',
+          parameters: {
+            type: 'object',
+            properties: {
+              dir: { type: 'string' }
+            },
+            required: ['dir']
+          }
+        },
+        {
           name: 'done',
           description: 'Finaliza a sessão',
           parameters: { type: 'object', properties: {} }
@@ -90,6 +112,22 @@ function loadProjectDocs() {
   return docs;
 }
 
+function readFile(pathname) {
+  try {
+    return fs.readFileSync(pathname, 'utf8');
+  } catch (err) {
+    return `erro ao ler arquivo: ${err.message}`;
+  }
+}
+
+function listFiles(dir) {
+  try {
+    return fs.readdirSync(dir).join('\n');
+  } catch (err) {
+    return `erro ao listar arquivos: ${err.message}`;
+  }
+}
+
 async function processChat(messages) {
   while(true){
     const msg = await chat(messages);
@@ -102,6 +140,12 @@ async function processChat(messages) {
       } else if(name === 'apply_patch'){
         const {patch} = JSON.parse(args);
         result = applyPatch(patch);
+      } else if(name === 'read_file'){
+        const {path} = JSON.parse(args);
+        result = readFile(path);
+      } else if(name === 'list_files'){
+        const {dir} = JSON.parse(args);
+        result = listFiles(dir);
       } else if(name === 'done'){
         console.log('Tarefa concluída.');
         return false;
@@ -166,4 +210,4 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   });
 }
 
-export {chat, runCommand, applyPatch, loadProjectDocs, processChat, main};
+export {chat, runCommand, applyPatch, readFile, listFiles, loadProjectDocs, processChat, main};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,7 @@ import {tmpdir} from 'os';
 import {join} from 'path';
 import {spawnSync} from 'child_process';
 import {test} from 'node:test';
-import {loadProjectDocs, runCommand, applyPatch} from '../index.js';
+import {loadProjectDocs, runCommand, applyPatch, readFile, listFiles} from '../index.js';
 
 
 test('loadProjectDocs inclui conteudo do README', () => {
@@ -34,4 +34,21 @@ test('applyPatch aplica patch git', () => {
   const content = fs.readFileSync('foo.txt', 'utf8');
   assert.strictEqual(content, 'world\n');
   process.chdir(cwd);
+});
+
+test('readFile retorna conteudo correto', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'agent-test-'));
+  const file = join(dir, 'example.txt');
+  fs.writeFileSync(file, 'conteudo');
+  const out = readFile(file);
+  assert.strictEqual(out, 'conteudo');
+});
+
+test('listFiles lista arquivos do diretorio', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'agent-test-'));
+  fs.writeFileSync(join(dir, 'a.txt'), '');
+  fs.writeFileSync(join(dir, 'b.txt'), '');
+  const out = listFiles(dir);
+  assert.ok(out.includes('a.txt'));
+  assert.ok(out.includes('b.txt'));
 });


### PR DESCRIPTION
## Summary
- add contributor guidelines
- support `read_file` and `list_files` functions
- export new functions
- update README with new features and testing instructions
- add unit tests for new helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a8eb570c08329a72b1eb048a5d73a