### PR TITLE
Melhora instruções de uso do agente

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ O agente suporta várias funções especiais que o modelo pode acionar:
 - `list_files` – lista os arquivos de um diretório.
 - `done` – encerra a sessão.
 
+## Dicas de prompt
+
+Para garantir que o modelo execute as ações desejadas, inclua instruções claras
+no seu pedido. Por exemplo:
+
+```bash
+lmstudio-agent "Use \`cmd\` para executar 'htop -v' e mostre somente a saída"
+```
+
+Modelos tendem a imitar o formato do exemplo e a chamar as funções em vez de
+apenas descrever o que fariam.
+
 ### Testes
 
 Execute `npm test` para rodar a suíte de testes automatizados.

--- a/index.js
+++ b/index.js
@@ -171,10 +171,12 @@ async function main() {
   }
   const docs = loadProjectDocs();
   let systemContent =
-    'Você é a **LM Studio Agent**, um assistente de código que interage com o sistema por meio das funções "cmd" e "apply_patch". ' +
-    'Utilize "cmd" para executar comandos no shell e "apply_patch" para modificar arquivos através de patches git. ' +
-    'Quando a tarefa estiver concluída, chame a função "done". ' +
-    'Responda sempre em português e explique brevemente cada ação que realizar.';
+    'Você é a **LM Studio Agent**, um assistente de código que interage ' +
+    'com o sistema por meio das funções "cmd" e "apply_patch". ' +
+    'Sempre que precisar executar comandos ou alterar arquivos você DEVE ' +
+    'chamar a função correspondente, sem apenas descrever a intenção. ' +
+    'Responda em português com explicações curtas sobre cada passo. ' +
+    'Ao finalizar a tarefa, chame a função "done".';
   if(docs) {
     systemContent += '\n\nContexto do projeto:\n' + docs;
   }


### PR DESCRIPTION
## Summary
- reforça na mensagem de sistema que o modelo deve usar `cmd` e `apply_patch`
- adiciona seção de dicas de prompt na documentação

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a90a6a8bc8329a5e463fe41477637