### PR TITLE
Add env options and curl docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,28 @@ Variáveis de ambiente:
 
 - `LM_BASE_URL` – URL da API do LM Studio.
 - `LM_MODEL` – modelo a ser utilizado.
+- `LM_TEMPERATURE` – temperatura das respostas (padrão 0.7).
+- `LM_MAX_TOKENS` – limite máximo de tokens (padrão -1).
+- `LM_STREAM` – defina como `true` para habilitar streaming.
+
+### Requisição com `curl`
+
+O exemplo abaixo mostra como enviar manualmente uma mensagem para o LM Studio:
+
+```bash
+curl http://localhost:1234/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "google/gemma-3-12b",
+    "messages": [
+      { "role": "system", "content": "Always answer in rhymes. Today is Thursday" },
+      { "role": "user", "content": "What day is it today?" }
+    ],
+    "temperature": 0.7,
+    "max_tokens": -1,
+    "stream": false
+}'
+```
 
 O agente suporta várias funções especiais que o modelo pode acionar:
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,13 @@ import {pathToFileURL} from 'url';
 
 const API_BASE = process.env.LM_BASE_URL || 'http://45.161.201.27:1234/v1';
 const MODEL = process.env.LM_MODEL || 'google/gemma-3-12b';
+const TEMPERATURE = process.env.LM_TEMPERATURE
+  ? parseFloat(process.env.LM_TEMPERATURE)
+  : 0.7;
+const MAX_TOKENS = process.env.LM_MAX_TOKENS
+  ? parseInt(process.env.LM_MAX_TOKENS, 10)
+  : -1;
+const STREAM = process.env.LM_STREAM === 'true';
 
 async function chat(messages) {
   let res;
@@ -18,7 +25,9 @@ async function chat(messages) {
       body: JSON.stringify({
         model: MODEL,
         messages,
-        temperature: 0,
+        temperature: TEMPERATURE,
+        max_tokens: MAX_TOKENS,
+        stream: STREAM,
         functions: [
         {
           name: 'cmd',


### PR DESCRIPTION
## Summary
- allow customizing temperature, max tokens and streaming via environment variables
- document new variables and provide a curl example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a934fe3608329925b4149f4f0ba00