### PR TITLE
Implement write_file function

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ O agente suporta várias funções especiais que o modelo pode acionar:
 - `apply_patch` – aplica um patch Git no repositório atual.
 - `read_file` – lê o conteúdo de um arquivo.
 - `list_files` – lista os arquivos de um diretório.
+- `write_file` – grava texto em um arquivo.
 - `done` – encerra a sessão.
 
 ## Dicas de prompt

--- a/index.js
+++ b/index.js
@@ -74,6 +74,18 @@ async function chat(messages) {
           }
         },
         {
+          name: 'write_file',
+          description: 'Escreve conteúdo em um arquivo',
+          parameters: {
+            type: 'object',
+            properties: {
+              path: { type: 'string' },
+              content: { type: 'string' }
+            },
+            required: ['path', 'content']
+          }
+        },
+        {
           name: 'done',
           description: 'Finaliza a sessão',
           parameters: { type: 'object', properties: {} }
@@ -137,6 +149,16 @@ function listFiles(dir) {
   }
 }
 
+// escreve conteúdo em um arquivo
+function writeFile(pathname, content) {
+  try {
+    fs.writeFileSync(pathname, content, 'utf8');
+    return 'arquivo escrito com sucesso';
+  } catch (err) {
+    return `erro ao escrever arquivo: ${err.message}`;
+  }
+}
+
 async function processChat(messages) {
   while(true){
     const msg = await chat(messages);
@@ -155,6 +177,9 @@ async function processChat(messages) {
       } else if(name === 'list_files'){
         const {dir} = JSON.parse(args);
         result = listFiles(dir);
+      } else if(name === 'write_file'){
+        const {path, content} = JSON.parse(args);
+        result = writeFile(path, content);
       } else if(name === 'done'){
         console.log('Tarefa concluída.');
         return false;
@@ -221,4 +246,4 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   });
 }
 
-export {chat, runCommand, applyPatch, readFile, listFiles, loadProjectDocs, processChat, main};
+export {chat, runCommand, applyPatch, readFile, listFiles, writeFile, loadProjectDocs, processChat, main};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,7 @@ import {tmpdir} from 'os';
 import {join} from 'path';
 import {spawnSync} from 'child_process';
 import {test} from 'node:test';
-import {loadProjectDocs, runCommand, applyPatch, readFile, listFiles} from '../index.js';
+import {loadProjectDocs, runCommand, applyPatch, readFile, listFiles, writeFile} from '../index.js';
 
 
 test('loadProjectDocs inclui conteudo do README', () => {
@@ -51,4 +51,13 @@ test('listFiles lista arquivos do diretorio', () => {
   const out = listFiles(dir);
   assert.ok(out.includes('a.txt'));
   assert.ok(out.includes('b.txt'));
+});
+
+test('writeFile cria e grava conteudo', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'agent-test-'));
+  const file = join(dir, 'novo.txt');
+  const msg = writeFile(file, 'abc');
+  const data = fs.readFileSync(file, 'utf8');
+  assert.strictEqual(data, 'abc');
+  assert.strictEqual(msg.trim(), 'arquivo escrito com sucesso');
 });


### PR DESCRIPTION
## Summary
- add a new `write_file` capability
- handle `write_file` in the agent
- document the function in README
- test file writing behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a951d0704832995fe1bc65ac64547