### PR TITLE
Handle invalid JSON in processChat

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,16 +5,16 @@ import {tmpdir} from 'os';
 import {join} from 'path';
 import {spawnSync} from 'child_process';
 import {test} from 'node:test';
-import {loadProjectDocs, runCommand, applyPatch, readFile, listFiles} from '../index.js';
+import * as agent from '../index.js';
 
 
 test('loadProjectDocs inclui conteudo do README', () => {
-  const docs = loadProjectDocs();
+  const docs = agent.loadProjectDocs();
   assert.ok(docs.includes('Agente LM Studio'));
 });
 
 test('runCommand retorna saida do comando', () => {
-  const out = runCommand('echo hello');
+  const out = agent.runCommand('echo hello');
   assert.strictEqual(out.trim(), 'hello');
 });
 
@@ -29,7 +29,7 @@ test('applyPatch aplica patch git', () => {
   fs.writeFileSync('foo.txt', 'world\n');
   const diff = spawnSync('git', ['diff'], {encoding: 'utf8'}).stdout;
   spawnSync('git', ['checkout', '--', 'foo.txt'], {encoding: 'utf8'});
-  const result = applyPatch(diff);
+  const result = agent.applyPatch(diff);
   assert.strictEqual(result.trim(), 'patch aplicado com sucesso');
   const content = fs.readFileSync('foo.txt', 'utf8');
   assert.strictEqual(content, 'world\n');
@@ -40,7 +40,7 @@ test('readFile retorna conteudo correto', () => {
   const dir = mkdtempSync(join(tmpdir(), 'agent-test-'));
   const file = join(dir, 'example.txt');
   fs.writeFileSync(file, 'conteudo');
-  const out = readFile(file);
+  const out = agent.readFile(file);
   assert.strictEqual(out, 'conteudo');
 });
 
@@ -48,7 +48,25 @@ test('listFiles lista arquivos do diretorio', () => {
   const dir = mkdtempSync(join(tmpdir(), 'agent-test-'));
   fs.writeFileSync(join(dir, 'a.txt'), '');
   fs.writeFileSync(join(dir, 'b.txt'), '');
-  const out = listFiles(dir);
+  const out = agent.listFiles(dir);
   assert.ok(out.includes('a.txt'));
   assert.ok(out.includes('b.txt'));
+});
+
+test('processChat lida com JSON inválido', async () => {
+  const originalChat = agent.chat;
+  let call = 0;
+  agent.setChat(async () => {
+    call++;
+    if (call === 1) {
+      return {function_call: {name: 'cmd', arguments: '{oops'}};
+    }
+    return {content: 'fim'};
+  });
+  const msgs = [{role: 'user', content: 'oi'}];
+  const cont = await agent.processChat(msgs);
+  assert.ok(cont);
+  assert.strictEqual(msgs[1].role, 'assistant');
+  assert.ok(msgs[2].content.startsWith('erro ao analisar'));
+  agent.setChat(originalChat);
 });


### PR DESCRIPTION
## Summary
- refactor `chat` to be overridable and export `setChat`
- handle JSON parsing errors in `processChat`
- test invalid JSON handling in `processChat`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a951d7d0483298f020946dd7027ea