### PR TITLE
Expand agent functions and improve JSON error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ O agente suporta várias funções especiais que o modelo pode acionar:
 - `apply_patch` – aplica um patch Git no repositório atual.
 - `read_file` – lê o conteúdo de um arquivo.
 - `list_files` – lista os arquivos de um diretório.
+- `write_file` – grava conteúdo em um arquivo.
 - `done` – encerra a sessão.
 
 ## Dicas de prompt


### PR DESCRIPTION
## Summary
- implement `write_file` command
- handle JSON parse errors in `processChat`
- allow injecting chat function for tests
- document new capability in README
- add tests for new function and error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a94b7476083299770bd1700a3d41b